### PR TITLE
#74 카카오 소셜 로그인 수정

### DIFF
--- a/src/main/java/swyp/qampus/login/converter/OAuthConverter.java
+++ b/src/main/java/swyp/qampus/login/converter/OAuthConverter.java
@@ -2,6 +2,7 @@ package swyp.qampus.login.converter;
 
 import org.springframework.security.crypto.password.PasswordEncoder;
 import swyp.qampus.login.entity.User;
+import swyp.qampus.university.domain.University;
 
 // OAuth 로그인 시, 카카오 프로필 정보를 User 엔티티로 변환하는 컨버터 클래스
 public class OAuthConverter {
@@ -22,4 +23,27 @@ public class OAuthConverter {
                 .password(passwordEncoder.encode(password))
                 .build();
     }
+
+    public static User toUser(Long userId,String email, String name, String nickname, String password, PasswordEncoder passwordEncoder, String profileImageUrl) {
+        return User.builder()
+                .userId(userId)
+                .email(email)
+                .name(name)
+                .nickname(nickname)
+                .password(passwordEncoder.encode(password))
+                .build();
+    }
+    public static User toUser(Long userId, String email, String name, String nickname, String password,
+                              PasswordEncoder passwordEncoder, String profileImageUrl,
+                              University university, String major) {
+        return User.builder()
+                .userId(userId)
+                .email(email)
+                .name(name)
+                .nickname(nickname)
+                .password(passwordEncoder.encode(password))
+                .major(major)
+                .build();
+    }
+
 }

--- a/src/main/java/swyp/qampus/login/converter/UserConverter.java
+++ b/src/main/java/swyp/qampus/login/converter/UserConverter.java
@@ -4,6 +4,7 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import swyp.qampus.login.dto.UserRequestDTO;
 import swyp.qampus.login.dto.UserResponseDTO;
 import swyp.qampus.login.entity.User;
+import swyp.qampus.university.domain.University;
 
 /**
  * User 엔티티와 DTO 간의 변환을 담당하는 변환기 클래스
@@ -33,9 +34,12 @@ public class UserConverter {
     @Schema(name = "회원가입 결과 응답 Dto")
     public static UserResponseDTO.JoinResultDTO toJoinResultDTO(User user) {
         return UserResponseDTO.JoinResultDTO.builder()
+                .userId(user.getUserId())
                 .email(user.getEmail())// 사용자 ID 설정
                 .name(user.getName())
                 .nickname(user.getNickname())
+                .major(user.getMajor())
+                .universityName(user.getUniversity() != null ? user.getUniversity().getUniversityName() : "미등록")
                 .createAt(user.getCreatedDate()) // 계정 생성 날짜 설정
                 .build();
     }

--- a/src/main/java/swyp/qampus/login/dto/UserResponseDTO.java
+++ b/src/main/java/swyp/qampus/login/dto/UserResponseDTO.java
@@ -4,6 +4,7 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import swyp.qampus.login.entity.User;
 
 import java.time.LocalDateTime;
 import java.util.List;
@@ -33,6 +34,8 @@ public class UserResponseDTO {
         private String profileImageUrl; // 카카오 이미지
         private LocalDateTime createAt; // 계정 생성 시간
     }
+
+
 
     /**
      * 단일 사용자 정보 응답 DTO (미리보기 용)

--- a/src/main/java/swyp/qampus/login/repository/UserRepository.java
+++ b/src/main/java/swyp/qampus/login/repository/UserRepository.java
@@ -1,5 +1,6 @@
 package swyp.qampus.login.repository;
 
+import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 import swyp.qampus.login.entity.User;
@@ -7,6 +8,6 @@ import swyp.qampus.login.entity.User;
 import java.util.Optional;
 @Repository
 public interface UserRepository extends JpaRepository<User, Long> {
-
+    @EntityGraph(attributePaths = {"university"})
     Optional<User> findByEmail(String email);
 }

--- a/src/main/java/swyp/qampus/login/service/CompleteSignupService.java
+++ b/src/main/java/swyp/qampus/login/service/CompleteSignupService.java
@@ -1,5 +1,6 @@
 package swyp.qampus.login.service;
 
+import lombok.extern.log4j.Log4j2;
 import swyp.qampus.login.config.data.RedisCustomServiceImpl;
 import swyp.qampus.login.dto.UserRequestDTO;
 import swyp.qampus.login.entity.User;
@@ -16,6 +17,7 @@ import swyp.qampus.university.repository.UniversityRepository;
 
 @Service
 @RequiredArgsConstructor
+@Log4j2
 public class CompleteSignupService {
 
     private final UserRepository userRepository;
@@ -24,11 +26,13 @@ public class CompleteSignupService {
     private final JWTUtil jwtUtil;
     private final ObjectMapper objectMapper = new ObjectMapper();
 
-    public String completeSignup(String email, UserRequestDTO.UserUniversityAndMajorDTO request) {
+    public String completeSignup(String email, UserRequestDTO.UserUniversityAndMajorDTO request, String existingToken) {
+        log.info("[completeSignup] 회원가입 완료 프로세스 시작 (email: {})", email);
         String key = "tempUser:" + email;
         String userJson = redisCustomService.getRedisData(key);
 
         if(userJson == null) {
+            log.warn("[completeSignup] Redis에서 임시 사용자 정보가 존재하지 않음 (key: {})", key);
             throw new ResponseStatusException(HttpStatus.NOT_FOUND, "임시로 저장된 사용자 정보가 존재하지 않거나 만료되었습니다.");
         }
 
@@ -36,7 +40,9 @@ public class CompleteSignupService {
 
         try {
             tempUser = objectMapper.readValue(userJson, User.class);
+            log.info("[completeSignup] Redis에서 임시 사용자 정보 가져옴");
         } catch (JsonProcessingException e) {
+            log.error("[completeSignup] 임시 사용자 정보를 파싱하는 중 오류 발생: {}", e.getMessage());
             throw new ResponseStatusException(HttpStatus.INTERNAL_SERVER_ERROR, "임시로 저장된 사용자 정보를 파싱하는 중 오류가 발생되었습니다.");
         }
 
@@ -55,11 +61,22 @@ public class CompleteSignupService {
 
         // 최종적으로 DB에 저장
         userRepository.save(updateUser);
+        log.info("[completeSignup] User 정보 업데이트 완료 (userId: {})", updateUser.getUserId());
 
         // Redis에 저장된 임시 데이터 삭제
         redisCustomService.deleteRedisData(key);
+        log.info("[completeSignup] Redis에서 임시 사용자 정보 삭제 (key: {})", key);
 
-        // 최종 JWT 토큰 생성 후 반환
-        return jwtUtil.createAccessToken(updateUser.getEmail(), updateUser.getUserId());
+        //  기존 JWT가 유효하면 새로운 JWT 발급하지 않고 그대로 반환
+        if (jwtUtil.validateToken(existingToken)) {
+            log.info("[completeSignup] 기존 JWT가 유효하므로 새로운 JWT를 발급하지 않음.");
+            return existingToken;
+        }
+
+        // 기존 JWT가 없거나 만료되었을 경우에만 새로운 JWT 발급
+        log.info("[completeSignup] 기존 JWT가 없거나 만료됨. 새로운 JWT 발급");
+        String newJwt = jwtUtil.createAccessToken(updateUser.getEmail(), updateUser.getUserId());
+        log.info("[completeSignup] 새로 발급된 JWT: {}", newJwt);
+        return newJwt;
     }
 }

--- a/src/main/java/swyp/qampus/login/service/OauthService.java
+++ b/src/main/java/swyp/qampus/login/service/OauthService.java
@@ -2,11 +2,12 @@ package swyp.qampus.login.service;
 
 
 import com.fasterxml.jackson.core.JsonProcessingException;
+import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import swyp.qampus.login.entity.User;
 
 public interface OauthService {
-    User oAuthLogin(String code, HttpServletResponse httpServletResponse);
+    User oAuthLogin(String code, HttpServletResponse httpServletResponse, HttpServletRequest httpServletRequest) throws JsonProcessingException;
 
     void kakaoLogout(String accessToken) throws JsonProcessingException;
 }

--- a/src/main/java/swyp/qampus/login/service/impl/OauthServiceImpl.java
+++ b/src/main/java/swyp/qampus/login/service/impl/OauthServiceImpl.java
@@ -1,5 +1,7 @@
 package swyp.qampus.login.service.impl;
 
+import jakarta.servlet.http.HttpServletRequest;
+import org.springframework.web.server.ResponseStatusException;
 import swyp.qampus.login.config.data.RedisCustomServiceImpl;
 import swyp.qampus.login.converter.OAuthConverter;
 import swyp.qampus.login.dto.KakaoDTO;
@@ -44,30 +46,61 @@ public class OauthServiceImpl implements OauthService {
      * @return 로그인한 사용자 객체 (기존 회원 또는 신규 생성된 회원)
      */
     @Override
-    public User oAuthLogin(String code, HttpServletResponse httpServletResponse) {
-
+    public User oAuthLogin(String code, HttpServletResponse httpServletResponse, HttpServletRequest httpServletRequest) {
+        log.info(" [oAuthLogin] 카카오 OAuth 로그인 시작");
         // 카카오 서버에서 인가 코드를 사용하여 액세스 토큰 요청
         KakaoDTO.OAuthToken oAuthToken = kakaoUtil.requestToken(code);
+        log.info("[oAuthLogin] 받은 카카오 액세스 토큰: {}", oAuthToken);
         System.out.println("oAuthToken = " + oAuthToken);
 
         // 액세스 토큰을 이용하여 카카오 사용자 프로필 정보 요청
         KakaoDTO.KakaoProfile kakaoProfile = kakaoUtil.requestProfile(oAuthToken);
         System.out.println("kakaoProfile = " + kakaoProfile);
+        log.info("[oAuthLogin] 받은 카카오 프로필 정보: {}", kakaoProfile);
 
         // 카카오에서 받은 이메일 정보를 기반으로 기존 사용자 조회
         Optional<User> queryUser = userRepository.findByEmail(kakaoProfile.getKakao_account().getEmail());
         System.out.println("queryUser = " + queryUser);
+        log.info(" [oAuthLogin] 기존 사용자 조회 결과: {}", queryUser.isPresent() ? "존재함" : "없음");
+
+        // 요청 헤더에서 기존 JWT 가져오기
+        String existingToken = httpServletRequest.getHeader("Authorization");
+        if (existingToken != null && existingToken.startsWith("Bearer ")) {
+            existingToken = existingToken.substring(7); //  "Bearer " 제거하여 JWT만 남김
+            log.info("[oAuthLogin] 클라이언트에서 보낸 기존 JWT: {}", existingToken);
+        } else {
+            log.info("[oAuthLogin] 기존 JWT 없음");
+        }
 
         // 기존 회원이 존재하는 경우
         if (queryUser.isPresent()) {
             User user = queryUser.get();
 
-            // JWT 액세스 토큰을 생성하여 응답 헤더에 추가
-            httpServletResponse.setHeader("Authorization", jwtUtil.createAccessToken(user.getEmail(), user.getUserId()));
-            return user; // 기존 사용자 반환
-        } else {
-            // 기존 회원이 존재하지 않는 경우, 새 사용자 생성
-            User tempUser = OAuthConverter.toUser(
+            if (user.getUniversity() == null) {
+                log.error("[oAuthLogin] university 정보가 조회되지 않음. (email: {})", user.getEmail());
+            } else {
+                log.info("[oAuthLogin] university 조회 성공: {}", user.getUniversity().getUniversityName());
+            }
+
+            // 기존 JWT가 유효한지 확인
+            if (existingToken != null && jwtUtil.validateToken(existingToken)) {
+                log.info("[oAuthLogin] 기존 JWT가 유효하므로 새로운 토큰을 발급하지 않음.");
+                httpServletResponse.setHeader("Authorization", "Bearer " + existingToken);
+                return user;
+            }
+
+            // 기존 JWT가 없거나 만료되었을 경우에만 새로운 JWT 발급
+            log.info("[oAuthLogin] 기존 JWT가 없거나 만료됨. 새로운 JWT 발급");
+            String newToken = jwtUtil.createAccessToken(user.getEmail(), user.getUserId());
+            httpServletResponse.setHeader("Authorization", "Bearer " + newToken);
+            log.info("[oAuthLogin] 새로 발급된 JWT: {}", newToken);
+            return user;
+        }
+        
+
+        // 기존 회원이 존재하지 않는 경우, 새 사용자 생성
+        log.info("[oAuthLogin] 기존 회원 없음, 임시 사용자 생성");
+        User tempUser = OAuthConverter.toUser(
                     // 이메일
                     kakaoProfile.getKakao_account().getEmail(),
                     // 이름
@@ -82,29 +115,32 @@ public class OauthServiceImpl implements OauthService {
                     kakaoProfile.getKakao_account().getProfile().getProfileImageUrl()
                     );
 
-
-            // 임시 사용자 정보를 Redisdp JSON 형태로 저장
-            ObjectMapper objectMapper = new ObjectMapper();
+        //  Redis에 기존 임시 사용자가 있는지 확인 후 저장
+        String key = "tempUser:" + tempUser.getEmail();
+        if (redisCustomService.getRedisData(key) == null) {
             try {
-                String userJson = objectMapper.writeValueAsString(tempUser);
-                String key = "tempUser:" + tempUser.getEmail();
-
-                // RedisCustomServiceImpl의 saveRedisData(key, value, limitTime)을 사용
-                redisCustomService.saveRedisData(key, userJson, 1800L);
+                String userJson = new ObjectMapper().writeValueAsString(tempUser);
+                redisCustomService.saveRedisData(key, userJson, 1800L); // 30분 유지
+                log.info("[oAuthLogin] 임시 사용자 정보를 Redis에 저장 (Key: {})", key);
             } catch (JsonProcessingException e) {
-                e.printStackTrace();
+                log.error("[oAuthLogin] 임시 사용자 Redis 저장 중 오류 발생: {}", e.getMessage());
             }
+        }
 
-            // 임시 로드인 상태용 JWT 발급(추가 정보 입력 전까지 사용)
-            String tempJwt = jwtUtil.createAccessToken(tempUser.getEmail(), tempUser.getUserId());
-            httpServletResponse.setHeader("Authorization",tempJwt);
-
-
-            // DB에는 저장하지 않고 임시 사용자 정보를 반환
+        // 기존 JWT가 유효하면 그대로 유지
+        if (existingToken != null && jwtUtil.validateToken(existingToken)) {
+            log.info("[oAuthLogin] 기존 JWT가 유효하므로 새로운 JWT를 발급하지 않음.");
+            httpServletResponse.setHeader("Authorization", "Bearer " + existingToken);
             return tempUser;
         }
-    }
 
+        // 기존 JWT가 없거나 만료되었을 경우에만 새로운 JWT 발급
+        String tempJwt = jwtUtil.createAccessToken(tempUser.getEmail(), tempUser.getUserId());
+        httpServletResponse.setHeader("Authorization", "Bearer " + tempJwt);
+        log.info("[oAuthLogin] 새로 발급된 JWT: {}", tempJwt);
+        return tempUser;
+
+    }
 
     @Override
     public void kakaoLogout(String accessToken) throws JsonProcessingException {

--- a/src/main/resources/application-secret.properties
+++ b/src/main/resources/application-secret.properties
@@ -1,0 +1,52 @@
+spring.application.name=qampus
+
+## test DB ??
+spring.datasource.driver-class-name=com.mysql.cj.jdbc.Driver
+spring.datasource.url=jdbc:mysql://127.0.0.1:3306/qucampus
+spring.datasource.username=hong
+spring.datasource.password=zxcv1234
+spring.jpa.hibernate.ddl-auto=create-drop
+spring.jpa.database-platform=org.hibernate.dialect.MySQLDialect
+
+## GPT??
+openai.model=gpt-4o-mini
+openai.api.key=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
+openai.api.url=https://api.openai.com/v1/chat/completions
+
+
+# Naver Object Storage
+ncp.storage.secretKey=ncp_iam_BPKMKRZhLeco3gLB1n3KygHd2jncONb03m
+ncp.storage.accessKey=ncp_iam_BPAMKR7qGvLmBFkXofKL
+ncp.storage.region=kr-standard
+ncp.storage.endpoint=https://kr.object.ncloudstorage.com
+
+## kakao
+spring.security.oauth2.client.registration.kakao.client-id=e4a82870f5fd57fa9c0327538daab1f3
+spring.security.oauth2.client.registration.kakao.client-secret=Sd9k2VxmIfnRctS4bc4YswhX4KlsefEr
+spring.security.oauth2.client.registration.kakao.client-authentication-method=client_secret_post
+spring.security.oauth2.client.registration.kakao.authorization-grant-type=authorization_code
+spring.security.oauth2.client.registration.kakao.redirect-uri=http://localhost:8080/auth/login/kakao
+spring.security.oauth2.client.registration.kakao.scope=profile_nickname,profile_image,account_email
+
+spring.security.oauth2.client.provider.kakao.authorization-uri=https://kauth.kakao.com/oauth/authorize
+spring.security.oauth2.client.provider.kakao.token-uri=https://kauth.kakao.com/oauth/token
+spring.security.oauth2.client.provider.kakao.user-info-uri=https://kapi.kakao.com/v2/user/me
+spring.security.oauth2.client.provider.kakao.user-name-attribute=id
+
+
+
+jwt.secret=fDEysqmgauEyvUkAa55TjDef3HK-NOtuQ1LwOc3eRrs=
+jwt.expiration=86400000
+
+spring.data.redis.host=localhost
+spring.data.redis.port=6379
+
+
+
+## loh
+logging.level.org.hibernate.type.descriptor.sql=trace
+spring.jpa.properties.hibernate.use_Sql_comments=true
+spring.jpa.properties.hibernate.format_sql=true
+spring.jpa.properties.hibernate.show_sql=true
+
+spring.jackson.serialization.WRITE_DATES_AS_TIMESTAMPS=false

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -55,3 +55,5 @@ spring.jpa.properties.hibernate.format_sql=true
 spring.jpa.properties.hibernate.show_sql=true
 
 spring.jackson.serialization.WRITE_DATES_AS_TIMESTAMPS=false
+
+spring.profiles.active=secret


### PR DESCRIPTION

## #️⃣연관된 이슈

> #74 카카오 소셜 로그인 문제 수정
- existingToekn추가
- OAuthConverter 빌더 양식 추가
- UserConverter 가입 후 데이터 조회 추가
- UserRepository에 EntityGraph 어노테이션 추가(대학교 이름 조회하기 위해서)
- Complete 회원가입 로직에 JWT 토큰 유무에 따른 발급 및 유지
- OAuthService에도 동일하게 로직 추가 및 로그 추가 -

## 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
