### PR TITLE
[# 136] 로그 아웃 수정

### DIFF
--- a/src/main/java/swyp/qampus/login/config/WebOAuthSecurityConfig.java
+++ b/src/main/java/swyp/qampus/login/config/WebOAuthSecurityConfig.java
@@ -88,9 +88,11 @@ public class WebOAuthSecurityConfig implements WebMvcConfigurer {
                 .csrf(csrf -> csrf.disable())
                 // 세션을 사용하지 않고, **Stateless(무상태) 인증 방식**으로 설정 (JWT 방식)
                 .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
+                .logout(logout -> logout.disable()) // '/logout' 처리 비활성화
                 // 요청별 접근 설정
                 .authorizeHttpRequests(authorize -> authorize
                         .requestMatchers("/swagger-ui/**","/v3/api-docs/**").permitAll()
+                        .requestMatchers("/auth/logout").permitAll()  // 로그아웃 엔드포인트 허용
                         .requestMatchers("**").permitAll() // 해당 URL은 인증 없이 접근 가능
                         .anyRequest().authenticated() // 그 외의 요청은 인증 필요
                 )

--- a/src/main/java/swyp/qampus/login/controller/OAuthController.java
+++ b/src/main/java/swyp/qampus/login/controller/OAuthController.java
@@ -1,34 +1,33 @@
 
 package swyp.qampus.login.controller;
 
-import com.amazonaws.Response;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import io.jsonwebtoken.Claims;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.media.Content;
-import io.swagger.v3.oas.annotations.media.ExampleObject;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.log4j.Log4j2;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
 import org.springframework.web.server.ResponseStatusException;
 import swyp.qampus.common.ResponseDto;
-import swyp.qampus.exception.ErrorCode;
 import swyp.qampus.login.converter.UserConverter;
-import swyp.qampus.login.dto.TokenResponseDto;
 import swyp.qampus.login.dto.UserRequestDTO;
 import swyp.qampus.login.dto.UserResponseDTO;
 import swyp.qampus.login.entity.User;
 import swyp.qampus.login.service.CompleteSignupService;
 import swyp.qampus.login.service.OauthService;
-import com.fasterxml.jackson.core.JsonProcessingException;
-import jakarta.servlet.http.HttpServletResponse;
-import lombok.RequiredArgsConstructor;
-
-import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.*;
 import swyp.qampus.login.util.JWTUtil;
-import swyp.qampus.question.domain.MyQuestionResponseDto;
 
+@Log4j2
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/auth")
@@ -73,35 +72,37 @@ public class OAuthController {
     }
 
     /**
-     * 카카오 로그아웃 API
-     * @param accessToken 클라이언트가 제공한 카카오 액세스 토큰 (`Authorization` 헤더에서 가져옴)
+     * 로그아웃 API
      * @return 로그아웃 성공 또는 실패 응답 메시지
      */
     @Operation(
-            summary = "카카오  로그아웃 API입니다.-[담당자 : 홍기문]",
+            summary = "로그아웃 API입니다.-[담당자 : 홍기문]",
+            description = "클라이언트가 제공한 JWT 토큰을 기반으로 카카오 로그아웃을 수행합니다. " +
+                    "토큰을 만료 처리하여 로그아웃을 완료합니다.",
             responses = {
-                    @ApiResponse(responseCode = "200", description = "카카오 로그아웃 성공",
+                    @ApiResponse(responseCode = "200", description = "로그아웃 성공",
                             content = @Content(mediaType = "application/json",
                                     schema = @Schema(implementation = ResponseDto.class))),
-                    @ApiResponse(responseCode = "500", description = "카카오 로그아웃 실패: ",
+                    @ApiResponse(responseCode = "500", description = "로그아웃 실패: ",
                             content = @Content(mediaType = "application/json",
                                     schema = @Schema(implementation = ResponseEntity.class))),
             }
     )
-    @PostMapping("/logout/kakao")
-    public ResponseEntity<?> logout(
-            @Parameter(description = "클라이언트가 제공한 카카오 액세스 토큰 (`Authorization` 헤더에서 가져옴)")
-            @RequestHeader("Authorization") String accessToken
-    ) {
-        try {
-            // 1. "Bearer " 접두어 제거 후, 실제 액세스 토큰만 추출
-            oauthService.kakaoLogout(accessToken.replace("Bearer ", "")); // 토큰에서 "Bearer " 제거 후 전달
+    @SecurityRequirement(name = "Bearer Authentication")
+    @PostMapping("/logout")
+    public ResponseEntity<?> logout(@Parameter(hidden = true) HttpServletRequest request) {
 
-            // 2. 카카오 로그아웃 성공 시 응답 반환
-            return ResponseEntity.ok(ResponseDto.of(true,200,"카카오 로그아웃 성공"));
-        } catch (JsonProcessingException e) {
-            // 3. JSON 파싱 중 예외 발생 시, 500 에러 반환
-            return ResponseEntity.status(500).body("카카오 로그아웃 실패: " + e.getMessage());
+        String token = jwtUtil.resolveToken(request);
+        if (token == null) {
+            return ResponseEntity.status(HttpStatus.BAD_REQUEST).body("토큰이 없습니다.");
+        }
+
+        try {
+            Claims claims = jwtUtil.getClaims(token);
+            String expiredToken = jwtUtil.createExpiredToken(claims.getSubject(), claims.get("userId", Long.class));
+            return ResponseEntity.ok().body(expiredToken); // 만료된 토큰 반환
+        } catch (Exception e) {
+            return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body("유효하지 않은 토큰");
         }
     }
 
@@ -139,6 +140,4 @@ public class OAuthController {
 
         return ResponseEntity.ok(ResponseDto.of(true,200,"회원가입이 완료되었습니다."));
     }
-
-
 }

--- a/src/main/java/swyp/qampus/login/service/OauthService.java
+++ b/src/main/java/swyp/qampus/login/service/OauthService.java
@@ -8,6 +8,4 @@ import swyp.qampus.login.entity.User;
 
 public interface OauthService {
     User oAuthLogin(String code, HttpServletResponse httpServletResponse, HttpServletRequest httpServletRequest) throws JsonProcessingException;
-
-    void kakaoLogout(String accessToken) throws JsonProcessingException;
 }

--- a/src/main/java/swyp/qampus/login/service/impl/OauthServiceImpl.java
+++ b/src/main/java/swyp/qampus/login/service/impl/OauthServiceImpl.java
@@ -1,6 +1,8 @@
 package swyp.qampus.login.service.impl;
 
 import jakarta.servlet.http.HttpServletRequest;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.web.client.HttpClientErrorException;
 import org.springframework.web.server.ResponseStatusException;
 import swyp.qampus.login.config.data.RedisCustomServiceImpl;
 import swyp.qampus.login.converter.OAuthConverter;
@@ -140,36 +142,5 @@ public class OauthServiceImpl implements OauthService {
         log.info("[oAuthLogin] 새로 발급된 JWT: {}", tempJwt);
         return tempUser;
 
-    }
-
-    @Override
-    public void kakaoLogout(String accessToken) throws JsonProcessingException {
-        // HTTP Header 생성
-        HttpHeaders headers = new HttpHeaders();
-        headers.setBearerAuth(accessToken);
-        headers.setContentType(MediaType.APPLICATION_FORM_URLENCODED);
-
-        // HTTP 요청 보내기
-        HttpEntity<MultiValueMap<String, String>> kakaoLogoutRequest = new HttpEntity<>(headers);
-        String url = "https://kapi.kakao.com/v1/user/logout";
-
-        ResponseEntity<String> response = restTemplate.exchange(
-                url,
-                HttpMethod.POST,
-                kakaoLogoutRequest,
-                String.class
-        );
-
-        // 응답 처리
-        if (response.getStatusCode() == HttpStatus.OK) {
-            ObjectMapper objectMapper = new ObjectMapper();
-            JsonNode jsonNode = objectMapper.readTree(response.getBody());
-
-            Long id = jsonNode.get("id").asLong();
-            log.info("카카오 로그아웃 완료 - 사용자 ID: {}", id);
-        } else {
-            log.error("카카오 로그아웃 실패 - 응답 코드: {}", response.getStatusCode());
-            throw new RuntimeException("카카오 로그아웃 실패");
-        }
     }
 }

--- a/src/main/java/swyp/qampus/login/service/impl/UserServiceImpl.java
+++ b/src/main/java/swyp/qampus/login/service/impl/UserServiceImpl.java
@@ -15,7 +15,6 @@ import swyp.qampus.login.service.UserService;
 import swyp.qampus.login.util.JWTUtil;
 import swyp.qampus.question.domain.MyQuestionResponseDto;
 import swyp.qampus.question.domain.Question;
-import swyp.qampus.question.exception.QuestionErrorCode;
 import swyp.qampus.question.repository.QuestionRepository;
 import swyp.qampus.university.domain.University;
 import swyp.qampus.university.repository.UniversityRepository;

--- a/src/test/java/swyp/qampus/login/LogoutControllerTest.java
+++ b/src/test/java/swyp/qampus/login/LogoutControllerTest.java
@@ -1,0 +1,77 @@
+/*package swyp.qampus.login;
+
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.MalformedJwtException;
+import jakarta.servlet.http.HttpServletRequest;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Import;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.web.servlet.MockMvc;
+import swyp.qampus.login.controller.OAuthController;
+import swyp.qampus.login.util.JWTUtil;
+
+
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+
+@SpringBootTest
+@AutoConfigureMockMvc
+public class LogoutControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockBean
+    private JWTUtil jwtUtil;
+
+    @Test
+    @WithMockUser
+    public void 로그아웃_성공_테스트() throws Exception {
+        // ✅ 올바른 JWT 형식 사용 (header.payload.signature)
+        String validToken = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJ1c2VySWQiLCJpYXQiOjE2MjAwMDAwMDB9.abc123";
+
+        Claims claims = Jwts.claims().setSubject("test@example.com");
+        claims.put("userId", 123L);
+
+        // ✅ Mock 설정
+        when(jwtUtil.resolveToken(any(HttpServletRequest.class))).thenReturn(validToken);
+        when(jwtUtil.getClaims(validToken)).thenReturn(claims);
+        when(jwtUtil.createExpiredToken(anyString(), anyLong())).thenReturn("expired.jwt.token");
+
+        mockMvc.perform(post("/auth/logout")
+                        .header("Authorization", "Bearer " + validToken))
+                .andExpect(status().isOk())
+                .andExpect(content().string("expired.jwt.token"));
+    }
+
+    @Test
+    @WithMockUser
+    public void 유효하지_않은_토큰_테스트() throws Exception {
+        // ✅ 올바른 형식이지만 잘못된 서명 포함
+        String invalidToken = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJ1c2VySWQiLCJpYXQiOjE2MjAwMDAwMDB9.wrong_signature";
+
+        // ✅ `MalformedJwtException`을 던지도록 설정
+        when(jwtUtil.resolveToken(any(HttpServletRequest.class))).thenReturn(invalidToken);
+        when(jwtUtil.getClaims(invalidToken)).thenThrow(new MalformedJwtException("잘못된 JWT 토큰"));
+
+        mockMvc.perform(post("/auth/logout")
+                        .header("Authorization", "Bearer " + invalidToken))
+                .andExpect(status().isUnauthorized())
+                .andExpect(content().string("유효하지 않은 토큰"));
+    }
+}
+ */


### PR DESCRIPTION
## #️⃣연관된 이슈

> #136 로그아웃 API 수정

## 📝작업 내용
- 카카오 로그아웃 기능 -> JWT 만료 로그아웃로 수정
- Security에 로그아웃 비활성화, 엔드포인트 허용
-  OAuthController /auth/logout/kakao -> /auth/logout로 변경
- kakaologout 메서드 삭제
- JWT 만료 기능,  Claims 객체에서 추출 메서드 추가

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)
### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
